### PR TITLE
remove in_order from all translators

### DIFF
--- a/pyquibbler/quib/specialized_functions/proxy.py
+++ b/pyquibbler/quib/specialized_functions/proxy.py
@@ -35,7 +35,7 @@ class ProxyBackwardsPathTranslator(BackwardsPathTranslator):
 
     SHOULD_ATTEMPT_WITHOUT_SHAPE_AND_TYPE = True
 
-    def translate_in_order(self) -> Dict[Source, Path]:
+    def translate(self) -> Dict[Source, Path]:
         return {
             source: self._path
             for source in self._func_call.get_data_sources()

--- a/pyquibbler/translation/backwards_path_translator.py
+++ b/pyquibbler/translation/backwards_path_translator.py
@@ -32,17 +32,9 @@ class BackwardsPathTranslator:
         return working_component(self._path)
 
     @abstractmethod
-    def translate_in_order(self) -> Dict[Source, Path]:
+    def translate(self) -> Dict[Source, Path]:
         """
         Translate the path back to a mapping between sources and their respective paths which have an equivalence to
         self._path
         """
         pass
-
-    def translate_without_order(self) -> Dict[Source, Path]:
-        """
-        Just like translate_in_order, but without any necessity to have the path in a specific order- the default
-        behavior is just to translate in order, but if you have the ability to translate out of order WITHOUT needing
-        shape or type, then override this method.
-        """
-        return self.translate_in_order()

--- a/pyquibbler/translation/numpy_translator.py
+++ b/pyquibbler/translation/numpy_translator.py
@@ -29,7 +29,7 @@ class NumpyBackwardsPathTranslator(BackwardsPathTranslator):
             current_components = []
         return current_components, components_at_end
 
-    def translate_in_order(self) -> Dict[Source, Path]:
+    def translate(self) -> Dict[Source, Path]:
         sources_to_paths = {}
         working, rest = self._split_path()
         for source in self._func_call.get_data_sources():

--- a/pyquibbler/translation/translate.py
+++ b/pyquibbler/translation/translate.py
@@ -14,13 +14,12 @@ class MultipleBackwardsTranslatorRunner(MultipleInstanceRunner):
     expected_runner_exception = FailedToTranslateException
     exception_to_raise_on_none_found = NoTranslatorsFoundException
 
-    def __init__(self, func_call: FuncCall, path: Path, shape, type_: Type, in_order: bool,
+    def __init__(self, func_call: FuncCall, path: Path, shape, type_: Type,
                  extra_kwargs_for_translator):
         super().__init__(func_call)
         self._path = path
         self._shape = shape
         self._type = type_
-        self._in_order = in_order
         self._extra_kwargs_for_translator = extra_kwargs_for_translator
 
     def _get_runners_from_definition(self, definition: FuncDefinition) -> List:
@@ -36,7 +35,7 @@ class MultipleBackwardsTranslatorRunner(MultipleInstanceRunner):
             type_=self._type,
             **self._extra_kwargs_for_translator
         )
-        return translator.translate_in_order() if self._in_order else translator.translate_without_order()
+        return translator.translate()
 
 
 class MultipleForwardsTranslatorRunner(MultipleInstanceRunner):
@@ -74,7 +73,6 @@ def backwards_translate(func_call: FuncCall,
     This gives a mapping of sources to paths that were referenced in given path in the result of the function
     """
     return MultipleBackwardsTranslatorRunner(func_call=func_call, path=path, shape=shape, type_=type_,
-                                             in_order=in_order,
                                              extra_kwargs_for_translator=kwargs).run()
 
 

--- a/pyquibbler/translation/translators/transpositional/getitem_translator.py
+++ b/pyquibbler/translation/translators/transpositional/getitem_translator.py
@@ -30,9 +30,9 @@ class BackwardsGetItemTranslator(BackwardsTranspositionalTranslator):
                and not self._path[0].references_field_in_field_array() \
                and isinstance(self._func_call.args[0].value, np.ndarray)
 
-    def translate_in_order(self) -> Dict[Source, Path]:
+    def translate(self) -> Dict[Source, Path]:
         if self._can_squash_start_of_path():
-            return super(BackwardsGetItemTranslator, self).translate_in_order()
+            return super(BackwardsGetItemTranslator, self).translate()
         return {
             self._func_call.args[0]: [_getitem_path_component(self._func_call), *self._path]
         }

--- a/pyquibbler/translation/translators/vectorize_translator.py
+++ b/pyquibbler/translation/translators/vectorize_translator.py
@@ -54,7 +54,7 @@ class VectorizeBackwardsPathTranslator(BackwardsPathTranslator):
         indices_in_data_source = self._backwards_translate_indices_to_bool_mask(source, working_component.component)
         return [PathComponent(self._type, indices_in_data_source)]
 
-    def translate_in_order(self) -> Dict[Source, Path]:
+    def translate(self) -> Dict[Source, Path]:
         return {source: self._get_source_path_in_source(source, self._path)
                 for source in self._func_call.get_data_sources()}
 


### PR DESCRIPTION
the concept of in_order translation is instead achieved by each inverter calling the specific translator of its choice to which it matches the corresponding value