### PR TITLE
Be more flexible with numpy version and other deps

### DIFF
--- a/pyquibbler/setup.py
+++ b/pyquibbler/setup.py
@@ -30,7 +30,7 @@ setup(
     long_description_content_type='text/markdown',
     packages=find_packages(),
     install_requires=["matplotlib==3.9.1",
-                      "numpy==2.0.1",
+                      "numpy>=2.0.1",
                       "varname==0.13",
 
                       # TODO: These following packages are not strictly needed.

--- a/pyquibbler/setup.py
+++ b/pyquibbler/setup.py
@@ -29,18 +29,18 @@ setup(
     long_description=long_description,
     long_description_content_type='text/markdown',
     packages=find_packages(),
-    install_requires=["matplotlib==3.9.1",
+    install_requires=["matplotlib>=3.9.1",
                       "numpy>=2.0.1",
-                      "varname==0.13",
+                      "varname>=0.13",
 
                       # TODO: These following packages are not strictly needed.
                       #       They enhance interactive functionality within Jupyter lab.
                       #       We might want to consider whether to define them as "required"
-                      "ipynbname==2021.3.2",
-                      "flask==2.1.1",
-                      "flask_cors==3.0.10",
+                      "ipynbname>=2021.3.2",
+                      "flask>=2.1.1",
+                      "flask_cors>=3.0.10",
                       "ipycytoscape",
-                      "ipywidgets==8.1",
+                      "ipywidgets>=8.1",
                       "traitlets",
                       "IPython",
                       ],


### PR DESCRIPTION
The current setup script requires exact versions but in a large project this make compatibility with other dependencies very hard and sometimes impossible.
For instance when you're using a modern dependency management library like Astral uv the install will fail because of this strict requirement.

This PR adds more flexibility to the requirements.